### PR TITLE
#5 Handle deletion of payments / receipts

### DIFF
--- a/Common/Services/DataServices/PaymentsService.cs
+++ b/Common/Services/DataServices/PaymentsService.cs
@@ -99,10 +99,12 @@ namespace Services.DataServices
 
         public async Task DeletePayment(Payments payments)
         {
+            var paymentPeriod = _paymentPeriodService.PaymentPeriodForDate(payments.StartDate!.Value);
+
             await _realmService.Realm.WriteAsync(() => {
                 _realmService.Realm.Remove(payments);
             });
-            var paymentPeriod = _paymentPeriodService.PaymentPeriodForDate(payments.StartDate!.Value);
+            
             if (paymentPeriod != null)
             {
                 await _budgetsService.FullPaymentPeriodBudgetResync(paymentPeriod.Id!.Value);

--- a/Mobile/Mobile/ViewModels/Scheduling/SchedulerPageViewModel.cs
+++ b/Mobile/Mobile/ViewModels/Scheduling/SchedulerPageViewModel.cs
@@ -90,9 +90,16 @@ namespace Mobile.ViewModels.Scheduling
             OUTGOING
         }
 
+        private SchedulerAppointment selectedSchedulerAppointment;
+
+        private TransactionTypesToView selectedTransactionTypesToView;
+
         private async Task ViewDailyTransactions(SchedulerAppointment schedulerEntry, TransactionTypesToView entryTypesToView)
         {
             var payments = await _paymentsService.GetPaymentsByDates(new DateTimeOffset(schedulerEntry.StartTime), new DateTimeOffset(schedulerEntry.EndTime));
+
+            selectedSchedulerAppointment = schedulerEntry;
+            selectedTransactionTypesToView = entryTypesToView;
 
             switch (entryTypesToView)
             {
@@ -114,6 +121,12 @@ namespace Mobile.ViewModels.Scheduling
         async Task DeleteDailyTransaction(ObjectId paymentId)
         {
             await _paymentsService.DeletePayment(DailyTransactionsDataSource.First(record => record.Id == paymentId));
+            await ViewDailyTransactions(selectedSchedulerAppointment, selectedTransactionTypesToView);
+            await QueryAppointments(CachedEventArgs);
+
+            // Close the popup when all transactions for that day have been removed
+            IsDailyTransactionScreenOpen = (DailyTransactionsDataSource.Count() > 0);
+            
         }
 
         [RelayCommand]


### PR DESCRIPTION
Where a payment / receipt is deleted, close the popup when there are no more items for that date Ensure we resync all budgets as appropriate once we've deleted a payment /receipt