### PR TITLE
Calculation bug fixed. Where the amount spent on a particular budget exceeded the amount allocated for it that amount falsified the total outstanding.

### DIFF
--- a/Common/Services/DataServices/BudgetsService.cs
+++ b/Common/Services/DataServices/BudgetsService.cs
@@ -31,7 +31,12 @@ namespace Services.DataServices
 
             foreach (var budget in paymentPeriod.Budgets.Where(record => record.Budget > 0))
             {
-                budgetTotal += (budget.Budget - budget.AmountSpent + budget.AmountReceived);
+                var currentBudgetTotal = (budget.Budget - budget.AmountSpent + budget.AmountReceived);
+                if (currentBudgetTotal!.Value < 0) {
+                    currentBudgetTotal = 0;
+                }
+
+                budgetTotal += currentBudgetTotal;
             }
 
             return budgetTotal;

--- a/Common/Services/DataServices/PaymentsService.cs
+++ b/Common/Services/DataServices/PaymentsService.cs
@@ -33,7 +33,7 @@ namespace Services.DataServices
                 var item = new DailySpendAndReceipts()
                 {
                     Date = dateToCheck,
-                    AmountSpent = _realmService.Realm
+                    AmountSpent = _realmService.Realm!
                     .All<Payments>()
                     .Where(record => record.StartDate == dateOffsetToCheck && record.AmountPaid > 0)
                     .ToList()
@@ -87,7 +87,7 @@ namespace Services.DataServices
 
         public async Task AddPayment(Payments payments)
         {
-            await _realmService.Realm.WriteAsync(() => {
+            await _realmService.Realm!.WriteAsync(() => {
                 _realmService.Realm.Add(payments);
             });
 
@@ -100,7 +100,7 @@ namespace Services.DataServices
 
         public async Task UpdatePayment(Payments payments)
         {
-            await _realmService.Realm.WriteAsync(() => {
+            await _realmService.Realm!.WriteAsync(() => {
                 _realmService.Realm.Add(payments, true);
             });
             var paymentPeriod = _paymentPeriodService.PaymentPeriodForDate(payments.StartDate!.Value);
@@ -114,7 +114,7 @@ namespace Services.DataServices
         {
             var paymentPeriod = _paymentPeriodService.PaymentPeriodForDate(payments.StartDate!.Value);
 
-            await _realmService.Realm.WriteAsync(() => {
+            await _realmService.Realm!.WriteAsync(() => {
                 _realmService.Realm.Remove(payments);
             });
             


### PR DESCRIPTION
Where the amount spent on a particular budget exceeded the amount allocated for it that amount falsified the total outstanding.