### PR TITLE
Summary of total amounts on the group Group headings now more pronounced Future payments where a payment period not created is now indicated better Budget screen now loads the current payment period when you load the screen

### DIFF
--- a/Mobile/Mobile/Common/Convertors/PaymentsToTotalAmountConvertor.cs
+++ b/Mobile/Mobile/Common/Convertors/PaymentsToTotalAmountConvertor.cs
@@ -1,0 +1,36 @@
+﻿using Models;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mobile.Common.Convertors
+{
+    public class PaymentsToTotalAmountConvertor : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            double result = 0;
+            var items = value as IEnumerable<FuturePayment>;
+            if (items != null)
+            {
+                if (items != null)
+                {
+                    foreach (var futurePayment in items)
+                    {
+                        result += futurePayment.PaymentExpectedAmount;
+                    }
+                }
+            }
+            return result;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Mobile/Mobile/ViewModels/Budgets/PaymentsForBudgetByPaymentPeriodPageViewModel.cs
+++ b/Mobile/Mobile/ViewModels/Budgets/PaymentsForBudgetByPaymentPeriodPageViewModel.cs
@@ -29,8 +29,7 @@ namespace Mobile.ViewModels.Budgets
                     var payments = (await _paymentsService.GetPaymentsByDates(SelectedPaymentPeriod.DateFrom.Value, SelectedPaymentPeriod.DateTo.Value)).ToList();
                     payments.ForEach(record => record.PaymentPeriod = SelectedPaymentPeriod);
                     DataSource = payments
-                        .OrderBy(record => record.PaymentTypeId.PaymentCategoryId.DisplayOrder)
-                        .OrderByDescending(record => record.StartDate);
+                        .OrderBy(record => record.PaymentTypeDescription);
                     
                     break;
             }
@@ -59,6 +58,7 @@ namespace Mobile.ViewModels.Budgets
         public async override void OnNavigatedTo(INavigationParameters parameters)
         {
             PaymentPeriodsDataSource = await _paymentPeriodService.GetPaymentPeriods();
+            SelectedPaymentPeriod = _paymentPeriodService.CurrentPaymentPeriod();
         }
     }
 }

--- a/Mobile/Mobile/Views/Budgets/PaymentsForBudgetByPaymentPeriodPage.xaml
+++ b/Mobile/Mobile/Views/Budgets/PaymentsForBudgetByPaymentPeriodPage.xaml
@@ -22,14 +22,11 @@
   
   <Grid>
     <Grid.RowDefinitions>
-      <RowDefinition
-  Height="auto" />
+      
       <RowDefinition
   Height="*" />
     </Grid.RowDefinitions>
-    <Label
-      Grid.Row="0"
-      Text="Displaying" />
+
     <syncfusion:SfListView
       Grid.Row="1"
       HeaderSize="90"
@@ -57,6 +54,7 @@
             
             <Label
               Text="Payment Period: "
+              VerticalTextAlignment="Center"
               Grid.Row="0"
               Grid.Column="0" />
 
@@ -75,6 +73,8 @@
             </editors:SfComboBox>
 
             <HorizontalStackLayout
+              Grid.Column="0"
+              Grid.ColumnSpan="2"
               Grid.Row="1">
               <Button
                 x:Name="btnExpandAll"

--- a/Mobile/Mobile/Views/FuturePayments/FuturePaymentsPage.xaml
+++ b/Mobile/Mobile/Views/FuturePayments/FuturePaymentsPage.xaml
@@ -14,6 +14,8 @@
     <ResourceDictionary>
       <convertors:EditableFuturePaymentCanSaveConvertor
         x:Key="editableFuturePaymentCanSaveConvertor" />
+      <convertors:PaymentsToTotalAmountConvertor
+        x:Key="paymentsToTotalAmountConvertor" />
     </ResourceDictionary>
   </ContentPage.Resources>
   
@@ -115,21 +117,12 @@ Height="auto" />
       x:Name="lvFuturePayments"
       ItemSize="80"
       HeaderSize="60"
+      GroupHeaderSize="70"
       ItemSpacing="5"
       AllowSwiping="True"      
       SwipeStarting="SfListView_SwipeStarting"
       AllowGroupExpandCollapse="False"
-      ItemsSource="{Binding DataSource}"
-      >
-
-      <syncfusion:SfListView.DataSource>
-        <data:DataSource>
-          <data:DataSource.GroupDescriptors>
-            <data:GroupDescriptor
-              PropertyName="PaymentPeriodId" />
-          </data:DataSource.GroupDescriptors>
-        </data:DataSource>
-      </syncfusion:SfListView.DataSource>
+      ItemsSource="{Binding DataSource}">
 
       <syncfusion:SfListView.HeaderTemplate>
         <DataTemplate>
@@ -155,6 +148,25 @@ Height="auto" />
          Text="There are no future payments, why not use the above button to add one?" />
       </syncfusion:SfListView.EmptyView>
 
+      <syncfusion:SfListView.GroupHeaderTemplate>
+        <DataTemplate>
+          <Grid>
+            <Grid.RowDefinitions>
+              <RowDefinition
+                Height="auto" />
+              <RowDefinition
+  Height="auto" />
+            </Grid.RowDefinitions>
+            <Label
+              Grid.Row="0"
+              StyleClass="LargePaymentAmountLabel"
+              Text="{Binding Key}" />
+            <Label
+              Grid.Row="1"
+              Text="{Binding Items, Converter={StaticResource paymentsToTotalAmountConvertor}, StringFormat='Subtotal: {0:C2}'}" />
+          </Grid>
+        </DataTemplate>
+      </syncfusion:SfListView.GroupHeaderTemplate>
       
       <syncfusion:SfListView.ItemTemplate>
         <DataTemplate>

--- a/Mobile/Mobile/Views/FuturePayments/FuturePaymentsPage.xaml.cs
+++ b/Mobile/Mobile/Views/FuturePayments/FuturePaymentsPage.xaml.cs
@@ -1,3 +1,6 @@
+using Models;
+using Syncfusion.Maui.DataSource;
+
 namespace Mobile.Views.FuturePayments;
 
 public partial class FuturePaymentsPage : ContentPage
@@ -5,7 +8,19 @@ public partial class FuturePaymentsPage : ContentPage
 	public FuturePaymentsPage()
 	{
 		InitializeComponent();
-	}
+
+        lvFuturePayments.DataSource.GroupDescriptors.Add(new GroupDescriptor()
+        {
+            PropertyName = "PaymentPeriodId",
+            KeySelector = (object obj1) =>
+            {
+                var item = (obj1 as FuturePayment);
+                if(item.PaymentPeriodId is null) return "No Payment Period Defined";
+                return item.PaymentPeriodId;
+            }
+        });
+
+    }
 
     private void SfListView_SwipeStarting(object sender, Syncfusion.Maui.ListView.SwipeStartingEventArgs e)
     {


### PR DESCRIPTION
Group headings now more pronounced
Future payments where a payment period not created is now indicated better
Budget screen now loads the current payment period when you load the screen